### PR TITLE
Refine env requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # dns-updater
 
-`dns-updater` retrieves the machine's public IP address and updates the Route53 A record for `raspberrypi.epsilonrhorho.club`.
+`dns-updater` retrieves the machine's public IP address and updates a Route53 A record. The specific record to update is supplied via an environment variable so the program can be used for any host name.
 
 ## Required environment variables
 
 - `HOSTED_ZONE_ID` – the ID of the Route53 hosted zone containing the record.
-- AWS credentials and region variables recognised by the AWS SDK such as `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_REGION` must also be configured so the program can authenticate with Route53.
+- `RECORD_NAME` – the fully qualified DNS record name to update.
+- `AWS_ACCESS_KEY_ID` – your AWS access key ID used to authenticate with Route53.
+- `AWS_SECRET_ACCESS_KEY` – your AWS secret access key.
 
 ## IAM policy requirements
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.36.3
 	github.com/aws/aws-sdk-go-v2/config v1.29.14
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.51.1
+	github.com/kelseyhightower/envconfig v1.4.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -26,3 +26,5 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.33.19 h1:1XuUZ8mYJw9B6lzAkXhqHlJd/Xv
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.19/go.mod h1:cQnB8CUnxbMU82JvlqjKR2HBOm3fe9pWorWBza6MBJ4=
 github.com/aws/smithy-go v1.22.2 h1:6D9hW43xKFrRx/tXXfAlIZc4JI+yQe6snnWcQyxSyLQ=
 github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
+github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=

--- a/main.go
+++ b/main.go
@@ -3,17 +3,31 @@ package main
 import (
 	"context"
 	"log"
-	"os"
+
+	"github.com/kelseyhightower/envconfig"
 
 	"github.com/epsilonrhorho/dns-updater/ipify"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	"github.com/aws/aws-sdk-go-v2/service/route53/types"
 )
 
+type Config struct {
+	HostedZoneID string `envconfig:"HOSTED_ZONE_ID" required:"true"`
+	RecordName   string `envconfig:"RECORD_NAME" required:"true"`
+	AccessKeyID  string `envconfig:"AWS_ACCESS_KEY_ID" required:"true"`
+	SecretKey    string `envconfig:"AWS_SECRET_ACCESS_KEY" required:"true"`
+}
+
 func main() {
+	var c Config
+	if err := envconfig.Process("", &c); err != nil {
+		log.Fatalf("failed to parse environment variables: %v", err)
+	}
+
 	client := ipify.NewClient(nil)
 	ip, err := client.GetIP(context.Background())
 	if err != nil {
@@ -21,12 +35,12 @@ func main() {
 	}
 	log.Println("Public IP:", ip)
 
-	zoneID := os.Getenv("HOSTED_ZONE_ID")
-	if zoneID == "" {
-		log.Fatal("HOSTED_ZONE_ID environment variable is required")
-	}
-
-	cfg, err := config.LoadDefaultConfig(context.Background())
+	cfg, err := config.LoadDefaultConfig(
+		context.Background(),
+		config.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(c.AccessKeyID, c.SecretKey, ""),
+		),
+	)
 	if err != nil {
 		log.Fatalf("failed to load AWS config: %v", err)
 	}
@@ -34,13 +48,13 @@ func main() {
 	r53 := route53.NewFromConfig(cfg)
 
 	_, err = r53.ChangeResourceRecordSets(context.Background(), &route53.ChangeResourceRecordSetsInput{
-		HostedZoneId: aws.String(zoneID),
+		HostedZoneId: aws.String(c.HostedZoneID),
 		ChangeBatch: &types.ChangeBatch{
 			Changes: []types.Change{
 				{
 					Action: types.ChangeActionUpsert,
 					ResourceRecordSet: &types.ResourceRecordSet{
-						Name:            aws.String("raspberrypi.epsilonrhorho.club"),
+						Name:            aws.String(c.RecordName),
 						Type:            types.RRTypeA,
 						TTL:             aws.Int64(300),
 						ResourceRecords: []types.ResourceRecord{{Value: aws.String(ip)}},


### PR DESCRIPTION
## Summary
- document required environment variables
- remove mention of AWS_REGION because Route53 is global
- expose credentials through envconfig and use them when creating the Route53 client

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6840880b08c4832da13d6f217760dbc2