### PR TITLE
Add Docker build and workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,26 @@
+name: Build Docker Image
+
+on:
+  push:
+    branches: [main]
+    tags: ['*']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build image
+        env:
+          LABEL: ${{ github.ref_type == 'tag' && github.ref_name || 'main' }}
+        run: |
+          docker buildx build --platform linux/arm64 \
+            --label version=$LABEL \
+            -t dns-updater:$LABEL \
+            --load .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1
+
+FROM --platform=$BUILDPLATFORM golang:1.23 AS builder
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /dns-updater .
+
+FROM scratch
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /dns-updater /dns-updater
+
+ENTRYPOINT ["/dns-updater"]


### PR DESCRIPTION
## Summary
- add a scratch-based Dockerfile that builds a static arm64 binary
- add a workflow that builds the Docker image on pushes to `main` and tags

## Testing
- `go vet ./...`
- `go build ./...`
- `docker buildx build --platform linux/arm64 --load -t dns-updater:test .` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e0f94f84832d920502985b81450f