### PR TITLE
Add persistent storage for IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - `RECORD_NAME` – the fully qualified DNS record name to update.
 - `AWS_ACCESS_KEY_ID` – your AWS access key ID used to authenticate with Route53.
 - `AWS_SECRET_ACCESS_KEY` – your AWS secret access key.
+- `STORAGE_PATH` – path to persist the last seen IP address between runs.
 
 ## IAM policy requirements
 


### PR DESCRIPTION
## Summary
- add `STORAGE_PATH` env var for persistent last IP storage
- only update Route53 when IP changes

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6840fe1006b0832d9458980269b8446a