### PR TITLE
Update TTL to 60 seconds

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func update(ctx context.Context, r53 *route53.Client, ipClient ipify.ClientInter
 					ResourceRecordSet: &types.ResourceRecordSet{
 						Name:            aws.String(c.RecordName),
 						Type:            types.RRTypeA,
-						TTL:             aws.Int64(300),
+						TTL:             aws.Int64(60),
 						ResourceRecords: []types.ResourceRecord{{Value: aws.String(ip)}},
 					},
 				},


### PR DESCRIPTION
## Summary
- set the DNS record TTL to 60 seconds

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6843824eeba0832d960f34541c9dcc5f