### PR TITLE
Add AWS_REGION configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - `RECORD_NAME` – the fully qualified DNS record name to update.
 - `AWS_ACCESS_KEY_ID` – your AWS access key ID used to authenticate with Route53.
 - `AWS_SECRET_ACCESS_KEY` – your AWS secret access key.
+- `AWS_REGION` – the AWS region to use when signing requests.
 - `STORAGE_PATH` – path to persist the last seen IP address between runs.
 
 ## IAM policy requirements
@@ -51,5 +52,5 @@ kubectl apply -f k8s/pvc.yaml
 kubectl apply -f k8s/deployment.yaml
 ```
 
-Edit `k8s/deployment.yaml` to fill in your `HOSTED_ZONE_ID` and `RECORD_NAME`
-values and to use the image you have pushed to a registry.
+Edit `k8s/deployment.yaml` to fill in your `HOSTED_ZONE_ID`, `RECORD_NAME` and
+`AWS_REGION` values and to use the image you have pushed to a registry.

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -22,6 +22,8 @@ spec:
           value: "<RECORD_NAME>"
         - name: STORAGE_PATH
           value: /data/last_ip
+        - name: AWS_REGION
+          value: "<AWS_REGION>"
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ type Config struct {
 	RecordName   string `envconfig:"RECORD_NAME" required:"true"`
 	AccessKeyID  string `envconfig:"AWS_ACCESS_KEY_ID" required:"true"`
 	SecretKey    string `envconfig:"AWS_SECRET_ACCESS_KEY" required:"true"`
+	Region       string `envconfig:"AWS_REGION" required:"true"`
 	StoragePath  string `envconfig:"STORAGE_PATH" required:"true"`
 }
 
@@ -81,6 +82,7 @@ func main() {
 	}
 	cfg, err := config.LoadDefaultConfig(
 		context.Background(),
+		config.WithRegion(c.Region),
 		config.WithCredentialsProvider(
 			credentials.NewStaticCredentialsProvider(c.AccessKeyID, c.SecretKey, ""),
 		),


### PR DESCRIPTION
## Summary
- add `AWS_REGION` to configuration in main.go
- document `AWS_REGION` in README
- pass region through Kubernetes deployment

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_6843891dabbc832db488c312ef89c8f1