### PR TITLE
Add ipify client tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Go Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Run gofmt
+        run: test -z "$(gofmt -l .)"
+      - name: Run tests
+        run: go test ./...

--- a/ipify/ipify_test.go
+++ b/ipify/ipify_test.go
@@ -1,0 +1,65 @@
+package ipify
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClientGetIPSuccess(t *testing.T) {
+	expectedIP := "1.2.3.4"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ip":"` + expectedIP + `"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.Client())
+	c.baseURL = srv.URL
+
+	ip, err := c.GetIP(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ip != expectedIP {
+		t.Fatalf("expected %s, got %s", expectedIP, ip)
+	}
+}
+
+func TestClientGetIPNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.Client())
+	c.baseURL = srv.URL
+
+	_, err := c.GetIP(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestClientGetIPInvalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`invalid`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.Client())
+	c.baseURL = srv.URL
+
+	_, err := c.GetIP(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var syntaxErr *json.SyntaxError
+	if !errors.As(err, &syntaxErr) {
+		t.Fatalf("expected json syntax error, got %T", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add unit tests for the ipify client
- run gofmt and `go test` in CI

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6848888d49e8832d82e3ff2d70a2de12