### PR TITLE
Remove gofmt check from test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,5 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: stable
-      - name: Run gofmt
-        run: test -z "$(gofmt -l .)"
       - name: Run tests
         run: go test ./...


### PR DESCRIPTION
## Summary
- Removed the gofmt formatting check step from the GitHub Actions test workflow
- Streamlines the CI process by focusing only on running tests

## Test plan
- [x] Verify the workflow file is updated correctly
- [ ] Confirm the test workflow still runs successfully without the gofmt step

🤖 Generated with [Claude Code](https://claude.ai/code)