### PR TITLE
Add systemd service support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,71 @@ kubectl apply -f k8s/deployment.yaml
 ```
 
 Edit `k8s/deployment.yaml` to fill in your `DNS_PROVIDER`, `ZONE`, `RECORD_NAME` and other required environment variables for your chosen provider.
+
+## Systemd service deployment
+
+For running `dns-updater` as a systemd service on Linux:
+
+1. **Build and install the binary:**
+   ```bash
+   go build -o dns-updater
+   sudo cp dns-updater /usr/local/bin/
+   sudo chmod +x /usr/local/bin/dns-updater
+   ```
+
+2. **Create a dedicated user:**
+   ```bash
+   sudo useradd --system --no-create-home --shell /bin/false dns-updater
+   ```
+
+3. **Create the storage directory:**
+   ```bash
+   sudo mkdir -p /var/lib/dns-updater
+   sudo chown dns-updater:dns-updater /var/lib/dns-updater
+   ```
+
+4. **Install the service file:**
+   ```bash
+   sudo cp dns-updater.service /etc/systemd/system/
+   ```
+
+5. **Edit the service file with your configuration:**
+   ```bash
+   sudo systemctl edit dns-updater.service
+   ```
+   
+   Add your configuration in the override file:
+   
+   **DNS Settings (required for all providers):**
+   ```ini
+   [Service]
+   Environment=ZONE=yourdomain.com
+   Environment=RECORD_NAME=home
+   ```
+   
+   **AWS Route53 Settings:**
+   ```ini
+   Environment=DNS_PROVIDER=route53
+   Environment=AWS_ACCESS_KEY_ID=your-access-key-id
+   Environment=AWS_SECRET_ACCESS_KEY=your-secret-access-key
+   Environment=AWS_REGION=us-east-1
+   ```
+   
+   **Cloudflare Settings:**
+   ```ini
+   Environment=DNS_PROVIDER=cloudflare
+   Environment=CF_API_TOKEN=your-api-token
+   ```
+
+6. **Enable and start the service:**
+   ```bash
+   sudo systemctl daemon-reload
+   sudo systemctl enable dns-updater.service
+   sudo systemctl start dns-updater.service
+   ```
+
+7. **Check the service status:**
+   ```bash
+   sudo systemctl status dns-updater.service
+   sudo journalctl -u dns-updater.service -f
+   ```

--- a/dns-updater.service
+++ b/dns-updater.service
@@ -1,0 +1,40 @@
+[Unit]
+Description=DNS Updater Service
+After=network.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=dns-updater
+Group=dns-updater
+ExecStart=/usr/local/bin/dns-updater
+Restart=always
+RestartSec=30
+StandardOutput=journal
+StandardError=journal
+
+# Environment variables
+Environment=DNS_PROVIDER=route53
+Environment=ZONE=example.com
+Environment=RECORD_NAME=home
+Environment=STORAGE_PATH=/var/lib/dns-updater/last-ip
+Environment=UPDATE_INTERVAL=2m
+Environment=TTL=60s
+
+# AWS Route53 credentials (uncomment and set if using Route53)
+#Environment=AWS_ACCESS_KEY_ID=your-access-key-id
+#Environment=AWS_SECRET_ACCESS_KEY=your-secret-access-key
+#Environment=AWS_REGION=us-east-1
+
+# Cloudflare credentials (uncomment and set if using Cloudflare)
+#Environment=CF_API_TOKEN=your-api-token
+
+# Security settings
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=yes
+ReadWritePaths=/var/lib/dns-updater
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- Add systemd service file with security hardening and proper user isolation
- Add comprehensive setup instructions to README with provider-specific configuration sections
- Support for both AWS Route53 and Cloudflare DNS providers

## Test plan
- [ ] Verify service file syntax is valid
- [ ] Test installation instructions on Linux system
- [ ] Confirm service starts and runs correctly
- [ ] Validate security settings are properly applied

🤖 Generated with [Claude Code](https://claude.ai/code)