### PR TITLE
Add YAML-based multi-record DNS configuration support

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,0 +1,24 @@
+update_interval: 2m
+storage_path: /tmp/dns-updater
+
+records:
+  foo.example.com:
+    provider: cloudflare
+    zone: example.com
+    ttl: 60s
+    cf_api_token: your_cloudflare_api_token_here
+    
+  bar.example.com:
+    provider: route53
+    zone: example.com
+    ttl: 300s
+    aws_access_key_id: your_aws_access_key_id
+    aws_secret_key: your_aws_secret_access_key
+    aws_region: us-east-1
+    
+  baz.subdomain.example.com:
+    provider: cloudflare
+    zone: subdomain.example.com
+    ttl: 120s
+    cf_email: your_email@example.com
+    cf_api_key: your_cloudflare_global_api_key

--- a/go.mod
+++ b/go.mod
@@ -24,4 +24,5 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.19 // indirect
 	github.com/aws/smithy-go v1.22.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -34,3 +34,6 @@ github.com/libdns/libdns v0.2.3 h1:ba30K4ObwMGB/QTmqUxf3H4/GmUrCAIkMWejeGl12v8=
 github.com/libdns/libdns v0.2.3/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
 github.com/libdns/route53 v1.5.1 h1:dkdcc2CKY/EHBBzAKqE0Cko7MKR8uVJ3GvpzwKu/UKM=
 github.com/libdns/route53 v1.5.1/go.mod h1:joT4hKmaTNKHEwb7GmZ65eoDz1whTu7KKYPS8ZqIh6Q=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Summary
- Replace environment variable configuration with YAML-based system for managing multiple DNS records
- Enable simultaneous management of multiple hostnames with different DNS providers
- Each record runs in separate goroutine with shared IP client for efficiency
- Separate storage paths per record to prevent conflicts

## Key Changes
- **Configuration format**: Switch from envconfig to YAML with `gopkg.in/yaml.v3`
- **Multi-record support**: Configure multiple DNS records in single YAML file
- **Provider flexibility**: Each record can use different DNS providers (Route53, Cloudflare) with separate credentials
- **Concurrent processing**: Each record update runs in its own goroutine
- **Storage isolation**: Separate storage paths prevent IP state conflicts between records

## Configuration Example
```yaml
update_interval: 2m
storage_path: /tmp/dns-updater

records:
  foo.example.com:
    provider: cloudflare
    zone: example.com
    ttl: 60s
    cf_api_token: your_token_here
    
  bar.example.com:
    provider: route53
    zone: example.com
    ttl: 300s
    aws_access_key_id: your_key_id
    aws_secret_key: your_secret_key
    aws_region: us-east-1
```

## Test plan
- [x] Build compiles successfully
- [x] YAML configuration loads and parses correctly
- [x] Multiple record configuration structure works
- [x] Documentation updated for new format
- [ ] Integration test with sample configuration
- [ ] Verify concurrent record updates work independently

🤖 Generated with [Claude Code](https://claude.ai/code)