### PR TITLE
Remove zone field from YAML config and auto-extract from record name

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -4,13 +4,11 @@ storage_path: /tmp/dns-updater
 records:
   foo.example.com:
     provider: cloudflare
-    zone: example.com
     ttl: 60s
     cf_api_token: your_cloudflare_api_token_here
     
   bar.example.com:
     provider: route53
-    zone: example.com
     ttl: 300s
     aws_access_key_id: your_aws_access_key_id
     aws_secret_key: your_aws_secret_access_key
@@ -18,7 +16,6 @@ records:
     
   baz.subdomain.example.com:
     provider: cloudflare
-    zone: subdomain.example.com
     ttl: 120s
     cf_email: your_email@example.com
     cf_api_key: your_cloudflare_global_api_key

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestExtractZoneFromRecordName(t *testing.T) {
+	tests := []struct {
+		name        string
+		recordName  string
+		expectedZone string
+		expectError bool
+	}{
+		{
+			name:        "valid 3-label record",
+			recordName:  "foo.example.com",
+			expectedZone: "example.com",
+			expectError: false,
+		},
+		{
+			name:        "valid 4-label record",
+			recordName:  "foo.bar.example.com",
+			expectedZone: "bar.example.com",
+			expectError: false,
+		},
+		{
+			name:        "valid 5-label record",
+			recordName:  "api.v1.prod.example.com",
+			expectedZone: "v1.prod.example.com",
+			expectError: false,
+		},
+		{
+			name:        "2-label record should error",
+			recordName:  "example.com",
+			expectError: true,
+		},
+		{
+			name:        "1-label record should error",
+			recordName:  "localhost",
+			expectError: true,
+		},
+		{
+			name:        "empty string should error",
+			recordName:  "",
+			expectError: true,
+		},
+		{
+			name:        "subdomain case",
+			recordName:  "web.staging.example.org",
+			expectedZone: "staging.example.org",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			zone, err := extractZoneFromRecordName(tt.recordName)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error for record name %q, but got none", tt.recordName)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error for record name %q: %v", tt.recordName, err)
+				return
+			}
+
+			if zone != tt.expectedZone {
+				t.Errorf("for record name %q, expected zone %q, got %q", tt.recordName, tt.expectedZone, zone)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Remove Zone field from RecordConfig struct to simplify configuration
- Add automatic zone extraction from record names with validation
- Update example configuration to reflect the simplified structure

## Changes
- **Removed** `Zone` field from `RecordConfig` struct in `main.go`
- **Added** `extractZoneFromRecordName()` function that extracts zone from record name
- **Added** validation to ensure record names have at least 3 DNS labels
- **Updated** main function to use extracted zone instead of configured zone
- **Updated** `config.yaml.example` to remove zone fields from all records
- **Added** comprehensive tests for the zone extraction functionality

## Zone Extraction Logic
The new function assumes the hostname is exactly one DNS label:
- `foo.example.com` → zone: `example.com`
- `api.staging.example.org` → zone: `staging.example.org`
- `web.prod.subdomain.example.com` → zone: `prod.subdomain.example.com`

Record names with fewer than 3 labels (e.g., `example.com`, `localhost`) will result in an error.

## Test plan
- [x] Run existing tests to ensure no regressions
- [x] Test zone extraction function with various valid and invalid inputs
- [x] Verify configuration parsing works without zone fields
- [x] Test error handling for invalid record names

🤖 Generated with [Claude Code](https://claude.ai/code)