### PR TITLE
Replace CONFIG_PATH environment variable with -c command-line flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -80,12 +81,10 @@ func loadConfig(configPath string) (*Config, error) {
 }
 
 func main() {
-	configPath := os.Getenv("CONFIG_PATH")
-	if configPath == "" {
-		configPath = "config.yaml"
-	}
+	configPath := flag.String("c", "/usr/local/etc/dns-updater.yaml", "path to configuration file")
+	flag.Parse()
 
-	config, err := loadConfig(configPath)
+	config, err := loadConfig(*configPath)
 	if err != nil {
 		log.Fatalf("failed to load configuration: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Replace CONFIG_PATH environment variable with proper command-line flag interface
- Add -c flag for specifying configuration file path with sensible default
- Update documentation to reflect the new CLI interface

## Changes
- **Removed** `CONFIG_PATH` environment variable usage from `main.go`
- **Added** `-c` flag using Go's `flag` package for configuration file path
- **Set** default configuration path to `/usr/local/etc/dns-updater.yaml`
- **Updated** `README.md` with new usage section and command-line options
- **Updated** systemd service example to use `-c` flag instead of environment variable

## Benefits
- **Cleaner CLI interface**: Standard Unix-style command-line flags instead of environment variables
- **Better discoverability**: Users can run `dns-updater -h` to see available options
- **Sensible defaults**: Uses standard system config location `/usr/local/etc/dns-updater.yaml`
- **Flexibility**: Still allows custom config paths via `-c` flag

## Usage
```bash
# Use default config location
dns-updater

# Use custom config file
dns-updater -c /path/to/config.yaml

# Show help
dns-updater -h
```

## Test plan
- [x] Verify `-c` flag works with custom config paths
- [x] Verify default config path is used when no flag specified
- [x] Verify help output shows correct flag documentation
- [x] Update documentation reflects new CLI interface

🤖 Generated with [Claude Code](https://claude.ai/code)